### PR TITLE
Make TravisCI test against latest possible dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.3.8
 before_install:
   - gem install bundler
+  - rm Gemfile.lock
 script:
   - bin/rspec
 jobs:


### PR DESCRIPTION
Noticed that you opted to check-in `Gemfile.lock`.

Adding this TravisCI config, as recommended in https://bundler.io/blog/2018/01/17/making-gem-development-a-little-better.html, so that at least you get feedback on possible failures with latest versions of the deps.